### PR TITLE
feat: support composableImpressionTracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This library is used to track impressions using a react useImpressionTracker hoo
 
 See [unit tests](src/index.test.tsx) for a detailed example for both the React Hook and Higher Order Component (HOC).
 
-```
+## Hook
+
+```typescript
 import { useImpressionTracker } from 'impression-tracker-react-hook';
 import { createEventLogger } from 'promoted-snowplow-logger';
 
@@ -33,6 +35,53 @@ const HookedExampleComponent = ({
   });
   return <div ref={ref}>{text}</div>;
 };
+```
+
+## Higher-Order Components (HOC)
+
+```typescript
+interface Props {
+  ...
+  // TODO - set this ref on the div.
+  impressionRef: (node?: Element | null) => void;
+  // Optional props.
+  impressionId: string;
+  // In case you want to log an impression early.
+  logImpressionFunctor: () => void;
+}
+
+class ExampleComponent extends React.Component<Props> {
+  ...
+  render() {
+    ...
+    return <div ref={this.props.impressionRef}>{text}</div>;
+  }
+}
+
+const WrappedExampleComponent = withImpressionTracker(ExampleComponent, {
+  handleError,
+  isEnabled: () => impressionLoggingEnabled,
+  getContentId: props => props.contentId,
+  getInsertionId: props => props.insertionId,
+  // Can be changed to modify the impression.
+  logImpression: eventLogger.logImpression,
+});
+```
+
+### Using Compose
+
+```typescript
+const WrappedExampleComponent = compose(
+  ...,
+  composableImpressionTracker({
+    handleError,
+    isEnabled: () => impressionLoggingEnabled,
+    getContentId: props => props.contentId,
+    getInsertionId: props => props.insertionId,
+    // Can be changed to modify the impression.
+    logImpression: eventLogger.logImpression,
+  })
+)(ExampleComponent);
 ```
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impression-tracker-react-hook",
-  "version": "7.4.0",
+  "version": "7.6.0",
   "description": "Tracks impressions in React using a Hook",
   "scripts": {
     "prettier": "prettier '**/*.{js,ts}' --ignore-path ./.prettierignore",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -205,10 +205,9 @@ export interface WithImpressionTrackerProps {
 /**
  * An HOC version of useImpressionProps.  If you can, use the hook instead.
  *
- * @param Component          the Component to wrap
- * @param getInsertionId     gets the insertionId from the props
- * @param innerLogImpression your logging code
- * @param handleError     what to do with errors
+ * @param Component the Component to wrap
+ * @param args      gets the insertionId from the props
+ * @returns a wrapped Component that supports impression tracking
  */
 export const withImpressionTracker = <P extends WithImpressionTrackerProps>(
   Component: React.ComponentType<P>,
@@ -225,10 +224,7 @@ export const withImpressionTracker = <P extends WithImpressionTrackerProps>(
       uuid,
       visibilityTimeThreshold,
     } = args;
-    let enable = isEnabled === undefined ? true : isEnabled(props);
-    if (enable == undefined) {
-      enable = true;
-    }
+    const enable = (isEnabled !== undefined ? isEnabled(props) : true) ?? true;
     const hookArgs: TrackerArguments = {
       enable,
       insertionId: enable && getInsertionId ? getInsertionId(props) : '',
@@ -251,4 +247,18 @@ export const withImpressionTracker = <P extends WithImpressionTrackerProps>(
   };
   fn.displayName = 'WithImpressionTracker';
   return fn;
+};
+
+// A version of HOC that can be used with connect.
+
+/**
+ * An HOC version of useImpressionProps that works with `compose`.  If you can, use the hook instead.
+ *
+ * @param args      gets the insertionId from the props
+ * @returns a `Function<Component, Component>` that works with `compose`
+ */
+export const composableImpressionTracker = <P extends WithImpressionTrackerProps>(
+  args: HocTrackerArguments<P>
+): ((Component: React.ComponentType<P>) => React.FC<Subtract<P, WithImpressionTrackerProps>>) => {
+  return (Component: React.ComponentType<P>) => withImpressionTracker(Component, args);
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -249,8 +249,6 @@ export const withImpressionTracker = <P extends WithImpressionTrackerProps>(
   return fn;
 };
 
-// A version of HOC that can be used with connect.
-
 /**
  * An HOC version of useImpressionProps that works with `compose`.  If you can, use the hook instead.
  *


### PR DESCRIPTION
Also includes:
- README about HOC and compose.
- A small change to a line (`enabled`) to remove a untested jest line.  It's not worth adding a test directly for this case.

TESTING=npm run test