### PR TITLE
refactor: fix the semantic release gha

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -31,7 +31,8 @@ jobs:
         run: npm run build
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        # Dan Hill reviewed this version.
+        uses: cycjimmy/semantic-release-action@v3.2.0
         id: semantic
         with:
           branch: main


### PR DESCRIPTION
This has broken in other repos.  This PR is marked as refactor so it doesn't bump the version.